### PR TITLE
Experiment with tables instead of records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ miette = "5.10.0"
 
 [dependencies.nu-plugin]
 path = ""
-version = "0.83.2"
+version = "0.89.0"
 
 [dependencies.nu-protocol]
 features = ["plugin"]
 path = ""
-version = "0.83.2"
+version = "0.89.0"
 
 [lib]
 bench = false
@@ -25,4 +25,4 @@ edition = "2021"
 license = "GPLv3"
 name = "nu_plugin_kdl"
 repository = "https://github.com/amtoine/nu_plugin_kdl"
-version = "0.83.2"
+version = "0.89.0"

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{Span, Value};
+use nu_protocol::{Record, Span, Value};
 
 use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
 
@@ -14,7 +14,7 @@ pub(crate) fn parse_document(document: &KdlDocument) -> Value {
         document.span().offset() + document.len(),
     );
 
-    Value::record(cols, vals, span)
+    Value::record(Record::from_raw_cols_vals(cols, vals), span)
 }
 
 fn parse_node(node: &KdlNode) -> Value {
@@ -51,11 +51,10 @@ fn parse_entry(entry: &KdlEntry) -> Value {
     };
 
     match entry.name() {
-        Some(name) => Value::Record {
-            cols: vec![name.value().to_string()],
-            vals: vec![value],
+        Some(name) => Value::record(
+            Record::from_raw_cols_vals(vec![name.value().to_string()], vec![value]),
             span,
-        },
+        ),
         None => value,
     }
 }


### PR DESCRIPTION
(Copy of [my messages](https://discord.com/channels/601130461678272522/855947301380947968/1204835843588628520) from Discord)

> I tried making it into a table instead of a record. its usable, but its horrible to use. Any ideas on how to improve this?
>
> ![image](https://github.com/amtoine/nu_plugin_kdl/assets/54412618/a5ab3e84-fbf0-4bb5-a0f5-99cf8fbc5436)
>
> One option is to only make it into a table if there's duplicated names, but im not sure if there's a clean way to do that. One way is to fold the KDL record into a Nushell record, and on each fold check if it has any duplicated keys, then if it has duplicated keys, convert that all into a table instead and continue. but that sound extremely inefficient.

fdncred suggested I take a look at `from xml` from the builtins.